### PR TITLE
Issue 41/active document error

### DIFF
--- a/ReasonCodeExample.XPathTools.Tests/Properties/AssemblyInfo.cs
+++ b/ReasonCodeExample.XPathTools.Tests/Properties/AssemblyInfo.cs
@@ -5,4 +5,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("Reason→Code→Example (http://reasoncodeexample.com)")]
 [assembly: AssemblyProduct("ReasonCodeExample.XPathTools.Tests")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("6.0.2.*")]
+[assembly: AssemblyVersion("6.0.3.*")]

--- a/ReasonCodeExample.XPathTools/ActiveDocument.cs
+++ b/ReasonCodeExample.XPathTools/ActiveDocument.cs
@@ -12,8 +12,16 @@ namespace ReasonCodeExample.XPathTools
             get
             {
                 ThreadHelper.ThrowIfNotOnUIThread();
-                var dte = (DTE)Package.GetGlobalService(typeof(DTE));
-                return dte?.ActiveDocument;
+                try
+                {
+                    var dte = (DTE)Package.GetGlobalService(typeof(DTE));
+                    return dte?.ActiveDocument;
+                }
+                catch(Exception ex)
+                {
+                    Console.Error.WriteLine($"Error retrieving '{nameof(DTE.ActiveDocument)}': {ex}");
+                    return null;
+                }
             }
         }
 

--- a/ReasonCodeExample.XPathTools/Properties/AssemblyInfo.cs
+++ b/ReasonCodeExample.XPathTools/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using ReasonCodeExample.XPathTools.Properties;
 [assembly: AssemblyCompany("Reason→Code→Example (http://reasoncodeexample.com)")]
 [assembly: AssemblyProduct("ReasonCodeExample.XPathTools")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("6.0.2.*")]
+[assembly: AssemblyVersion("6.0.3.*")]
 [assembly: InternalsVisibleTo(InternalsVisibleTo.ReasonCodeExampleXPathToolsTests)]
 [assembly: InternalsVisibleTo(InternalsVisibleTo.DynamicProxyGenAssembly2)]
 [assembly: InternalsVisibleTo(InternalsVisibleTo.CastleCore)]

--- a/ReasonCodeExample.XPathTools/VisualStudioIntegration/source.extension.vsixmanifest
+++ b/ReasonCodeExample.XPathTools/VisualStudioIntegration/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ReasonCodeExample.XPathInformation.v1.0" Version="6.0.2" Language="en-US" Publisher="Uli Weltersbach" />
+        <Identity Id="ReasonCodeExample.XPathInformation.v1.0" Version="6.0.3" Language="en-US" Publisher="Uli Weltersbach" />
         <DisplayName>XPath Tools</DisplayName>
         <Description xml:space="preserve">Run XPaths and XPath functions. Browse through results at the click of a button.
 Track and copy XPaths incl. XML namespaces in various formats, taking the hassle out of complex documents.</Description>

--- a/ReasonCodeExample.XPathTools/release-notes.txt
+++ b/ReasonCodeExample.XPathTools/release-notes.txt
@@ -1,4 +1,4 @@
-﻿v6.0.3: Attempt to gracefully handle exceptions when accessing the currently active document. See issue #41 for details (https://github.com/uli-weltersbach/XPathTools/issues/41).
+﻿v6.0.3: Gracefully handle exceptions seemingly caused by accessing the currently active document via the "Edit Project File" VS2019 contet menu entry. See issue #41 for details (https://github.com/uli-weltersbach/XPathTools/issues/41).
 v6.0.2: The XPath format used in the statusbar is now persisted correctly. See issue #42 for details (https://github.com/uli-weltersbach/XPathTools/issues/42).
 v6.0.1: XPath Runner query results now change focus to their source document when clicked. See issue #38 for details (https://github.com/uli-weltersbach/XPathTools/issues/38).
 v6.0.0: Async package load implemented as required by Visual Studio 2019.1 and later. Support for Visual Studio 2013 and earlier has been dropped as a consequence.

--- a/ReasonCodeExample.XPathTools/release-notes.txt
+++ b/ReasonCodeExample.XPathTools/release-notes.txt
@@ -1,4 +1,5 @@
-﻿v6.0.2: The XPath format used in the statusbar is now persisted correctly. See issue #42 for details (https://github.com/uli-weltersbach/XPathTools/issues/42).
+﻿v6.0.3: Attempt to gracefully handle exceptions when accessing the currently active document. See issue #41 for details (https://github.com/uli-weltersbach/XPathTools/issues/41).
+v6.0.2: The XPath format used in the statusbar is now persisted correctly. See issue #42 for details (https://github.com/uli-weltersbach/XPathTools/issues/42).
 v6.0.1: XPath Runner query results now change focus to their source document when clicked. See issue #38 for details (https://github.com/uli-weltersbach/XPathTools/issues/38).
 v6.0.0: Async package load implemented as required by Visual Studio 2019.1 and later. Support for Visual Studio 2013 and earlier has been dropped as a consequence.
 v5.3.0: Supported Visual Studio version range updated to include VS 2019 Preview. See issue #36 for details (https://github.com/uli-weltersbach/XPathTools/issues/36).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: '6.0.2-{build}'
+version: '6.0.3-{build}'
 image: Visual Studio 2017
 configuration: Release
 platform: Any CPU


### PR DESCRIPTION
Gracefully handle exceptions seemingly caused by accessing the currently active document via the "Edit Project File" VS2019 contet menu entry. See issue #41 for details.